### PR TITLE
Cast account id to int

### DIFF
--- a/ldap_servers/src/LdapUserManager.php
+++ b/ldap_servers/src/LdapUserManager.php
@@ -235,7 +235,7 @@ class LdapUserManager extends LdapBaseManager {
       return FALSE;
     }
 
-    $identifier = $this->externalAuth->get($account->id(), 'ldap_user');
+    $identifier = $this->externalAuth->get((int)$account->id(), 'ldap_user');
     if ($identifier) {
       return $this->getUserDataByIdentifier($identifier);
     }


### PR DESCRIPTION
Fix strict typing error in call to Drupal\externalauth\Authmap::get()

hotfix: php8-bugs